### PR TITLE
 custom option of row

### DIFF
--- a/src/js/freeze-table.js
+++ b/src/js/freeze-table.js
@@ -330,6 +330,7 @@
      */
     var columnWrapStyles = this.options.columnWrapStyles || null;
     var columnNum = this.options.columnNum || 1;
+    var rowIndex = this.options.rowIndex || 1;
     var columnKeep = (typeof this.options.columnKeep !== 'undefined') ? this.options.columnKeep : false;
       // Shadow option
       var defaultColumnBorderWidth = (this.shadow) ? 0 : 1;
@@ -439,11 +440,12 @@
        */
       // Get width by fixed column with number setting
       var width = 0 + columnBorderWidth;
+      var tr = that.$table.find('tr:nth-child(' + rowIndex + ')');
       for (var i = 1; i <= columnNum; i++) {
         // th/td detection
-        var th = that.$table.find('th:nth-child('+i+')').outerWidth();
-        var addWidth = (th > 0) ? th : that.$table.find('td:nth-child('+i+')').outerWidth();
-        width += addWidth;
+          var th = tr.find('th:nth-child(' + i + ')').outerWidth();
+          var addWidth = (th > 0) ? th : tr.find('td:nth-child(' + i + ')').outerWidth();
+          width += addWidth;
       }
       that.$columnTableWrap.width(width);
 


### PR DESCRIPTION
Add a custom option of which row that the freezed columns belong to.
It will be useful in this situation:
![image](https://user-images.githubusercontent.com/22684109/93840865-6cf4e600-fcc4-11ea-8e43-dd9a68108a98.png)
![image](https://user-images.githubusercontent.com/22684109/93840447-06bb9380-fcc3-11ea-9494-7a11595d03d3.png)
And I can use `$('.freeze-table').freezeTable({columnNum: 3, rowIndex: 2});` to freeze 3 columns on right way.